### PR TITLE
GH-2: AMQP: Exercise Second Proxy for ChannelProxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 .idea/
 out/
 ci/pipeline.yml
+.DS_Store

--- a/spring-amqp-rabbit/build.gradle
+++ b/spring-amqp-rabbit/build.gradle
@@ -8,6 +8,7 @@ plugins {
 dependencies {
 	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
 	implementation("org.springframework.boot:spring-boot-starter-amqp")
+	implementation("org.springframework.amqp:spring-rabbit:3.0.0-SNAPSHOT")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 

--- a/spring-amqp-rabbit/src/aotTest/java/com/example/amqp/AmqpRabbitApplicationAotTests.java
+++ b/spring-amqp-rabbit/src/aotTest/java/com/example/amqp/AmqpRabbitApplicationAotTests.java
@@ -32,7 +32,7 @@ class AmqpRabbitApplicationAotTests {
 	@Test
 	void rabbitListenerMethodReceivesMessageAndSendsResponse(AssertableOutput output) {
 		Awaitility.await().atMost(Duration.ofSeconds(30))
-				.untilAsserted(() -> assertThat(output).hasSingleLineContaining("++++++ Received: FOO"));
+				.untilAsserted(() -> assertThat(output).hasSingleLineContaining("++++++ Received: ONEtwo"));
 	}
 
 }

--- a/spring-amqp-rabbit/src/main/java/com/example/amqp/AmqpRabbitApplication.java
+++ b/spring-amqp-rabbit/src/main/java/com/example/amqp/AmqpRabbitApplication.java
@@ -1,8 +1,14 @@
 package com.example.amqp;
 
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -17,21 +23,52 @@ public class AmqpRabbitApplication {
 		Thread.currentThread().join(); // To be able to measure memory consumption
 	}
 
-	@RabbitListener(id = "graal", queues = "graal")
+	@Autowired
+	CachingConnectionFactory ccf;
+
+	@RabbitListener(id = "graal1", queues = "graal1")
 	@SendTo
 	public String upperCaseIt(String in) {
-		return in.toUpperCase();
+		try {
+			String two = sendWithConfirms();
+			return in.toUpperCase() + two;
+		}
+		catch (Exception e) {
+			throw new AmqpRejectAndDontRequeueException("fail");
+		}
+	}
+
+	@RabbitListener(id = "graal2", queues = "graal2")
+	@SendTo
+	public String lowerCaseIt(String in) {
+		return in.toLowerCase();
+	}
+
+	private String sendWithConfirms() throws Exception {
+		CachingConnectionFactory ccf = new CachingConnectionFactory(this.ccf.getRabbitConnectionFactory());
+		ccf.setPublisherConfirmType(CachingConnectionFactory.ConfirmType.CORRELATED);
+		RabbitTemplate template = new RabbitTemplate(ccf);
+		CorrelationData data = new CorrelationData();
+		String result = (String) template.convertSendAndReceive("", "graal2", "TWO", data);
+		data.getFuture().get(10, TimeUnit.SECONDS);
+		ccf.resetConnection();
+		return result;
 	}
 
 	@Bean
-	public Queue queue() {
-		return new Queue("graal");
+	public Queue queue1() {
+		return new Queue("graal1");
+	}
+
+	@Bean
+	public Queue queue2() {
+		return new Queue("graal2");
 	}
 
 	@Bean
 	public ApplicationRunner runner(RabbitTemplate template) {
 		return args -> {
-			System.out.println("++++++ Received: " + template.convertSendAndReceive("", "graal", "foo"));
+			System.out.println("++++++ Received: " + template.convertSendAndReceive("", "graal1", "one"));
 		};
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-aot-smoke-tests/issues/2

When using publisher confirms, the `ChannelProxy` also implements
`PublisherCallbackChannel`; a hint was added for that proxy, but the smoke
test did not use it.