### PR TITLE
Enhanced tests and set the application name

### DIFF
--- a/cloud-task/src/aotTest/java/com/example/cloud/task/CloudTaskApplicationAotTests.java
+++ b/cloud-task/src/aotTest/java/com/example/cloud/task/CloudTaskApplicationAotTests.java
@@ -16,8 +16,8 @@ class CloudTaskApplicationAotTests {
 	@Test
 	void expectedLoggingIsProduced(AssertableOutput output) {
 		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
-			assertThat(output).hasSingleLineContaining("Before task: application").hasSingleLineContaining("Task ran!")
-					.hasSingleLineContaining("After task: application");
+			assertThat(output).hasSingleLineContaining("Before task: cloudtask").hasSingleLineContaining("Task ran!")
+					.hasSingleLineContaining("After task: cloudtask");
 		});
 	}
 

--- a/cloud-task/src/main/resources/application.properties
+++ b/cloud-task/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+logging.level.org.springframework.cloud.task=DEBUG
+spring.application.name=cloudtask
+spring.aop.proxy-target-class=false


### PR DESCRIPTION
Also set the spring.aop.proxy-target-class to false until feature is ready in Spring framework

These changes take advantages of hints added to the Spring Cloud Task Project and should set the build back to green for this sample.