### PR TITLE
Allow reachability metadata version and url to be configured

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+reachabilityMetadataVersion=0.1.1
+#reachabilityMetadataUrl=


### PR DESCRIPTION
See https://github.com/oracle/graalvm-reachability-metadata/releases/tag/0.1.1, with that we should be able to remove some hints but let's do that in subsequent commits.