### PR TITLE
Add a Gradle property to use Maven local repository

### DIFF
--- a/gradle-plugins/aot-smoke-test-plugin/src/main/java/org/springframework/aot/gradle/AotSmokeTestPlugin.java
+++ b/gradle-plugins/aot-smoke-test-plugin/src/main/java/org/springframework/aot/gradle/AotSmokeTestPlugin.java
@@ -70,6 +70,9 @@ public class AotSmokeTestPlugin implements Plugin<Project> {
 		SourceSet aotTest = javaExtension.getSourceSets().create("aotTest");
 		javaExtension.setSourceCompatibility(JavaVersion.VERSION_17);
 		javaExtension.setTargetCompatibility(JavaVersion.VERSION_17);
+		if ("true".equals(project.getProperties().get("useMavenLocal"))) {
+			project.getRepositories().mavenLocal();
+		}
 		project.getRepositories().mavenCentral();
 		project.getRepositories().maven((repo) -> {
 			repo.setName("Spring Milestone");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 reachabilityMetadataVersion=0.1.1
 #reachabilityMetadataUrl=
+#useMavenLocal=true


### PR DESCRIPTION
Disabled by default.
Enabled via useMavenLocal=true in the root gradle.properties.
Useful for local testing of Spring snapshots for example.