### PR TITLE
 Remove overidde of spring.aop.proxy-target-class from cloud-task

### DIFF
--- a/cloud-task/src/main/resources/application.properties
+++ b/cloud-task/src/main/resources/application.properties
@@ -1,3 +1,2 @@
 logging.level.org.springframework.cloud.task=DEBUG
 spring.application.name=cloudtask
-spring.aop.proxy-target-class=false


### PR DESCRIPTION
With the addition of CGLib this is no longer necessary.