### PR TITLE
Fix cassandra keyspace setup

### DIFF
--- a/data-cassandra-reactive/src/main/java/com/example/data/cassandra/reactive/CassandraConfiguration.java
+++ b/data-cassandra-reactive/src/main/java/com/example/data/cassandra/reactive/CassandraConfiguration.java
@@ -15,11 +15,11 @@ class CassandraConfiguration {
 	@Bean
 	CqlSession cqlSession(CqlSessionBuilder cqlSessionBuilder, CassandraProperties properties) {
 		// This creates the keyspace on startup
-		try (CqlSession session = cqlSessionBuilder.build()) {
+		try (CqlSession session = cqlSessionBuilder.withKeyspace((String) null).build()) {
 			session.execute(CreateKeyspaceCqlGenerator
 					.toCql(CreateKeyspaceSpecification.createKeyspace(properties.getKeyspaceName()).ifNotExists()));
 		}
-		return cqlSessionBuilder.build();
+		return cqlSessionBuilder.withKeyspace(properties.getKeyspaceName()).build();
 	}
 
 }

--- a/data-cassandra/src/main/java/com/example/data/cassandra/CassandraConfiguration.java
+++ b/data-cassandra/src/main/java/com/example/data/cassandra/CassandraConfiguration.java
@@ -15,11 +15,11 @@ class CassandraConfiguration {
 	@Bean
 	CqlSession cqlSession(CqlSessionBuilder cqlSessionBuilder, CassandraProperties properties) {
 		// This creates the keyspace on startup
-		try (CqlSession session = cqlSessionBuilder.build()) {
+		try (CqlSession session = cqlSessionBuilder.withKeyspace((String) null).build()) {
 			session.execute(CreateKeyspaceCqlGenerator
 					.toCql(CreateKeyspaceSpecification.createKeyspace(properties.getKeyspaceName()).ifNotExists()));
 		}
-		return cqlSessionBuilder.build();
+		return cqlSessionBuilder.withKeyspace(properties.getKeyspaceName()).build();
 	}
 
 }


### PR DESCRIPTION
Initially one needs to connect to the system keyspace to create the target one, otherwise the DB will choke on non existing keypsace provided in configuration.