### PR TITLE
Update Batch sample to use File IO

### DIFF
--- a/batch/batch/src/appTest/java/com/example/batch/BatchApplicationAotTests.java
+++ b/batch/batch/src/appTest/java/com/example/batch/BatchApplicationAotTests.java
@@ -16,7 +16,7 @@ class BatchApplicationAotTests {
 	@Test
 	void expectedLoggingIsProduced(AssertableOutput output) {
 		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
-			assertThat(output).hasSingleLineContaining("Step 1 running");
+			assertThat(output).hasLineContaining("Found <Person");
 		});
 	}
 

--- a/batch/batch/src/main/java/com/example/batch/BatchApplication.java
+++ b/batch/batch/src/main/java/com/example/batch/BatchApplication.java
@@ -1,14 +1,33 @@
 package com.example.batch;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ImportRuntimeHints;
 
 @SpringBootApplication
+@ImportRuntimeHints(BatchApplication.BatchApplicationRuntimeHints.class)
 public class BatchApplication {
 
 	public static void main(String[] args) throws InterruptedException {
-		SpringApplication.run(BatchApplication.class, args);
+		List<String> newArgs = new ArrayList<>(Arrays.asList(args));
+		newArgs.add("fileName=persons.csv");
+		SpringApplication.run(BatchApplication.class, newArgs.toArray(String[]::new));
 		Thread.currentThread().join(); // To be able to measure memory consumption
+	}
+
+	static class BatchApplicationRuntimeHints implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			hints.resources().registerPattern("persons.csv");
+		}
+
 	}
 
 }

--- a/batch/batch/src/main/java/com/example/batch/BatchConfiguration.java
+++ b/batch/batch/src/main/java/com/example/batch/BatchConfiguration.java
@@ -1,29 +1,72 @@
 package com.example.batch;
 
+import javax.sql.DataSource;
+
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.file.FlatFileItemReader;
+import org.springframework.batch.item.file.builder.FlatFileItemReaderBuilder;
+import org.springframework.batch.item.file.mapping.RecordFieldSetMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration(proxyBeanMethods = false)
 class BatchConfiguration {
 
 	@Bean
-	public Job job(JobRepository jobRepository, Step step1) {
-		return new JobBuilder("job", jobRepository).start(step1).build();
+	@StepScope
+	public FlatFileItemReader<Person> reader(@Value("#{jobParameters['fileName']}") String fileName) {
+		return new FlatFileItemReaderBuilder<Person>().name("personItemReader")
+				.resource(new ClassPathResource(fileName)).delimited().names("firstName", "lastName")
+				.fieldSetMapper(new RecordFieldSetMapper<>(Person.class)).build();
 	}
 
 	@Bean
-	public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-		return new StepBuilder("step1", jobRepository).tasklet((stepContribution, chunkContext) -> {
-			System.out.println("Step 1 running");
-			return RepeatStatus.FINISHED;
-		}, transactionManager).build();
+	@JobScope // Not really needed, but just to test native support for job scoped Lambdas
+	@RegisterReflectionForBinding(Person.class)
+	public ItemProcessor<Person, Person> processor() {
+		return item -> new Person(item.firstName().toUpperCase(), item.lastName().toUpperCase());
+
+	}
+
+	@Bean
+	public JdbcBatchItemWriter<Person> writer(DataSource dataSource) {
+		return new JdbcBatchItemWriterBuilder<Person>()
+				.itemSqlParameterSourceProvider(new BeanPropertyItemSqlParameterSourceProvider<>())
+				.sql("INSERT INTO person (first_name, last_name) VALUES (:firstName, :lastName)").dataSource(dataSource)
+				.build();
+	}
+
+	@Bean
+	public JobCompletionNotificationListener notificationListener(JdbcTemplate jdbcTemplate) {
+		return new JobCompletionNotificationListener(jdbcTemplate);
+	}
+
+	@Bean
+	public Step step1(JobRepository jobRepository, FlatFileItemReader<Person> itemReader,
+			ItemProcessor<Person, Person> itemProcessor, JdbcBatchItemWriter<Person> itemWriter,
+			PlatformTransactionManager transactionManager) {
+		return new StepBuilder("step1", jobRepository).<Person, Person>chunk(2, transactionManager).reader(itemReader)
+				.processor(itemProcessor).writer(itemWriter).build();
+	}
+
+	@Bean
+	public Job job(JobRepository jobRepository, Step step, JobCompletionNotificationListener listener) {
+		return new JobBuilder("job", jobRepository).start(step).listener(listener).build();
 	}
 
 }

--- a/batch/batch/src/main/java/com/example/batch/JobCompletionNotificationListener.java
+++ b/batch/batch/src/main/java/com/example/batch/JobCompletionNotificationListener.java
@@ -1,0 +1,31 @@
+package com.example.batch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class JobCompletionNotificationListener implements JobExecutionListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(JobCompletionNotificationListener.class);
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JobCompletionNotificationListener(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public void afterJob(JobExecution jobExecution) {
+		if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+			jdbcTemplate
+					.query("SELECT first_name, last_name FROM person",
+							(resultSet, row) -> new Person(resultSet.getString(1), resultSet.getString(2)))
+					.forEach(person -> LOGGER.info("Found <" + person + "> in the database."));
+		}
+	}
+
+}

--- a/batch/batch/src/main/java/com/example/batch/Person.java
+++ b/batch/batch/src/main/java/com/example/batch/Person.java
@@ -1,0 +1,4 @@
+package com.example.batch;
+
+public record Person(String firstName, String lastName) {
+}

--- a/batch/batch/src/main/resources/persons.csv
+++ b/batch/batch/src/main/resources/persons.csv
@@ -1,0 +1,5 @@
+Jill,Doe
+Joe,Doe
+Justin,Doe
+Jane,Doe
+John,Doe

--- a/batch/batch/src/main/resources/schema-all.sql
+++ b/batch/batch/src/main/resources/schema-all.sql
@@ -1,0 +1,7 @@
+DROP TABLE person IF EXISTS;
+
+CREATE TABLE person
+(
+    first_name VARCHAR(20),
+    last_name  VARCHAR(20)
+);


### PR DESCRIPTION
This commit updates the `batch` sample to make the item reader reads data from a flat file (disk IO). This is an updated version of the Batch [getting started guide](https://spring.io/guides/gs/batch-processing/). Personally, I see no need to create two Batch samples (as mentioned in #10), but it is up to the native team to decide on this.

The goal of this PR is to port https://github.com/spring-projects-experimental/spring-native/pull/1618 from the experimental repository to this one. I took the opportunity to test the related issue (https://github.com/spring-projects-experimental/spring-native/issues/459) with the latest changes in Spring Native (as of 3e08cfd5eb116dcb1f5af819d5a2a892936f4f66) but the sample is still failing in AOT mode.

Any update on when this issue will be addressed?