### PR TITLE
Add data-jpa test that uses AbstractPersistable

### DIFF
--- a/data/data-jpa/src/appTest/java/com/example/data/jpa/DataJpaApplicationAotTests.java
+++ b/data/data-jpa/src/appTest/java/com/example/data/jpa/DataJpaApplicationAotTests.java
@@ -80,4 +80,12 @@ class DataJpaApplicationAotTests {
 		});
 	}
 
+	@Test
+	void abstractPersistable(AssertableOutput output) {
+
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			assertThat(output).hasLineMatching(".*Publisher\\{name='independently published', id=\\d.*\\}");
+		});
+	}
+
 }

--- a/data/data-jpa/src/main/java/com/example/data/jpa/CLR.java
+++ b/data/data-jpa/src/main/java/com/example/data/jpa/CLR.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import com.example.data.jpa.model.Author;
 import com.example.data.jpa.model.Book;
 
+import com.example.data.jpa.model.Publisher;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +20,12 @@ class CLR implements CommandLineRunner {
 
 	private final BookRepository bookRepository;
 
-	CLR(AuthorRepository authorRepository, BookRepository bookRepository) {
+	private final PublisherRepository publisherRepository;
+
+	CLR(AuthorRepository authorRepository, BookRepository bookRepository, PublisherRepository publisherRepository) {
 		this.authorRepository = authorRepository;
 		this.bookRepository = bookRepository;
+		this.publisherRepository = publisherRepository;
 	}
 
 	@Override
@@ -34,6 +38,7 @@ class CLR implements CommandLineRunner {
 		queryFindByName();
 		deleteAll();
 		entityGraph();
+		insertPublishers(); // uses AbstractPersistable
 	}
 
 	private void deleteAll() {
@@ -97,6 +102,12 @@ class CLR implements CommandLineRunner {
 		System.out.printf("insertAuthors(): author2 = %s%n", author2);
 
 		return Arrays.asList(author1, author2);
+	}
+
+	private List<Publisher> insertPublishers() {
+		Publisher publisher1 = this.publisherRepository.save(new Publisher("independently published"));
+		System.out.printf("insertPublishers(): publisher1 - %s%n", publisher1);
+		return List.of(publisher1);
 	}
 
 }

--- a/data/data-jpa/src/main/java/com/example/data/jpa/PublisherRepository.java
+++ b/data/data-jpa/src/main/java/com/example/data/jpa/PublisherRepository.java
@@ -1,0 +1,8 @@
+package com.example.data.jpa;
+
+import com.example.data.jpa.model.Publisher;
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface PublisherRepository extends ListCrudRepository<Publisher, Long> {
+
+}

--- a/data/data-jpa/src/main/java/com/example/data/jpa/model/Publisher.java
+++ b/data/data-jpa/src/main/java/com/example/data/jpa/model/Publisher.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.jpa.model;
+
+import jakarta.persistence.Entity;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+@Entity
+public class Publisher extends AbstractPersistable<Long> {
+
+	private String name;
+
+	protected Publisher() {
+	}
+
+	public Publisher(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String toString() {
+		return "Publisher{name='" + name + "', id=" + getId() + '}';
+	}
+
+}


### PR DESCRIPTION
Add reproducer for spring-projects/spring-data-jpa#2735. 
Will fail with an exception like below until spring-projects/spring-data-jpa#2737 is merged to _main_.
```
org.springframework.beans.factory.BeanCreationException: 
Error creating bean with name 'entityManagerFactory': Entity 'com.example.data.jpa.model.Publisher' has no identifier (every '@Entity' class must declare or inherit at least one '@Id' or '@EmbeddedId' property)
```
