### PR TITLE
Add a json-path into the picture for Integration

### DIFF
--- a/integration/integration/build.gradle
+++ b/integration/integration/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	implementation('org.springframework.integration:spring-integration-jdbc')
 	implementation('org.springframework.integration:spring-integration-redis')
 	implementation('io.micrometer:micrometer-core')
+	implementation('com.jayway.jsonpath:json-path')
 
 	runtimeOnly('com.h2database:h2')
 
@@ -26,4 +27,3 @@ dependencies {
 aotSmokeTest {
 	webApplication = true
 }
-

--- a/integration/integration/src/main/java/com/example/integration/IntegrationApplication.java
+++ b/integration/integration/src/main/java/com/example/integration/IntegrationApplication.java
@@ -89,6 +89,7 @@ public class IntegrationApplication {
 	MessageHandler loggingHandler() {
 		LoggingHandler loggingHandler = new LoggingHandler(LoggingHandler.Level.TRACE);
 		loggingHandler.setLoggerName("tracing.data");
+		loggingHandler.setLogExpressionString("#jsonPath(payload.toString(), '$')");
 		return loggingHandler;
 	}
 

--- a/integration/integration/src/main/resources/application.properties
+++ b/integration/integration/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.integration.endpoint.no-auto-startup=dateSourceEndpoint
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT_6379:6379}
+logging.level.tracing.data=trace


### PR DESCRIPTION
Spring Integration registers a SpEL function for json-path which is definitely called by reflection from SpEL. 
Add `#jsonPath()` SpEL function logic into the app to be sure that all the reflection hints are registered properly for native image

Related to https://github.com/spring-projects/spring-integration/issues/3990