### PR TITLE
Add test for hibernate lazy loading using enhanced types

### DIFF
--- a/framework/hibernate-enhancer/README.adoc
+++ b/framework/hibernate-enhancer/README.adoc
@@ -1,0 +1,1 @@
+Tests if Spring ORM - Hibernate enhanced types works

--- a/framework/hibernate-enhancer/build.gradle
+++ b/framework/hibernate-enhancer/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot'
+	id 'org.springframework.aot.smoke-test'
+	id 'org.graalvm.buildtools.native'
+	id 'org.hibernate.orm' version "6.1.6.Final"
+}
+
+hibernate {
+	enhancement {
+		lazyInitialization = true
+	}
+}
+
+dependencies {
+	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+	implementation("org.springframework.boot:spring-boot-starter-jdbc")
+	implementation("org.springframework:spring-orm")
+	implementation("jakarta.persistence:jakarta.persistence-api")
+	implementation("org.hibernate.orm:hibernate-core")
+	runtimeOnly("com.h2database:h2")
+
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+	appTestImplementation(project(":aot-smoke-test-support"))
+	appTestImplementation("org.awaitility:awaitility:4.2.0")
+}

--- a/framework/hibernate-enhancer/src/appTest/java/com/example/spring/orm/HibernateApplicationAotTests.java
+++ b/framework/hibernate-enhancer/src/appTest/java/com/example/spring/orm/HibernateApplicationAotTests.java
@@ -1,0 +1,23 @@
+package com.example.spring.orm;
+
+import java.time.Duration;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.smoketest.support.assertj.AssertableOutput;
+import org.springframework.aot.smoketest.support.junit.ApplicationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ApplicationTest
+class HibernateApplicationAotTests {
+
+	@Test
+	void lazyLoading(AssertableOutput output) {
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			assertThat(output).hasLineContaining("lazy - category.product: lazy-loading-works :)");
+		});
+	}
+
+}

--- a/framework/hibernate-enhancer/src/main/java/com/example/spring/orm/CLR.java
+++ b/framework/hibernate-enhancer/src/main/java/com/example/spring/orm/CLR.java
@@ -1,0 +1,57 @@
+package com.example.spring.orm;
+
+import com.example.spring.orm.model.Category;
+import com.example.spring.orm.model.Product;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class CLR implements CommandLineRunner {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Override
+	public void run(String... args) {
+		var categoryId = insertTestData();
+		lazyLoad(categoryId);
+	}
+
+	public void lazyLoad(Long id) {
+
+		clearCache();
+
+		Category result = entityManager.find(Category.class, id);
+		System.out.println("lazy - category.product: " + result.getProduct().getName());
+	}
+
+	public Long insertTestData() {
+
+		Product product = new Product();
+		product.setName("lazy-loading-works :)");
+		entityManager.persist(product);
+
+		Category category = new Category(product);
+		entityManager.persist(category);
+		Long categoryId = category.getId();
+
+		entityManager.flush();
+
+		return categoryId;
+	}
+
+	void clearCache() {
+
+		Session s = (Session) entityManager.getDelegate();
+		SessionFactory sf = s.getSessionFactory();
+		sf.getCache().evictEntityData();
+		s.clear();
+	}
+
+}

--- a/framework/hibernate-enhancer/src/main/java/com/example/spring/orm/HibernateEnhancedApplication.java
+++ b/framework/hibernate-enhancer/src/main/java/com/example/spring/orm/HibernateEnhancedApplication.java
@@ -1,0 +1,16 @@
+package com.example.spring.orm;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@SpringBootApplication
+@EnableTransactionManagement
+public class HibernateEnhancedApplication {
+
+	public static void main(String[] args) throws InterruptedException {
+		SpringApplication.run(HibernateEnhancedApplication.class, args);
+		Thread.currentThread().join(); // To be able to measure memory consumption
+	}
+
+}

--- a/framework/hibernate-enhancer/src/main/java/com/example/spring/orm/model/Category.java
+++ b/framework/hibernate-enhancer/src/main/java/com/example/spring/orm/model/Category.java
@@ -1,0 +1,34 @@
+package com.example.spring.orm.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Category {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY) //
+	private Product product;
+
+	public Category(Product product) {
+		this.product = product;
+	}
+
+	protected Category() {
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Product getProduct() {
+		return product;
+	}
+
+}

--- a/framework/hibernate-enhancer/src/main/java/com/example/spring/orm/model/Product.java
+++ b/framework/hibernate-enhancer/src/main/java/com/example/spring/orm/model/Product.java
@@ -1,0 +1,28 @@
+package com.example.spring.orm.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Product {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/framework/hibernate-enhancer/src/main/resources/application.properties
+++ b/framework/hibernate-enhancer/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.org.hibernate.SQL=debug


### PR DESCRIPTION
This PR adds a test that uses hibernate [Bytecode Enhancement](https://docs.jboss.org/hibernate/orm/6.1/userguide/html_single/Hibernate_User_Guide.html#BytecodeEnhancement) to generate entities that have lazy loading capabilities added to the domain types so that those bits are baked right into the image.