### PR TITLE
Add healthcheck to Pulsar docker-compose

### DIFF
--- a/integration/spring-pulsar-reactive/docker-compose.yml
+++ b/integration/spring-pulsar-reactive/docker-compose.yml
@@ -6,3 +6,5 @@ services:
       - '8080'
       - '6650'
     command: bin/pulsar standalone
+    healthcheck:
+      test: curl http://127.0.0.1:8080/admin/v2/namespaces/public/default

--- a/integration/spring-pulsar/docker-compose.yml
+++ b/integration/spring-pulsar/docker-compose.yml
@@ -6,3 +6,5 @@ services:
       - '8080'
       - '6650'
     command: bin/pulsar standalone
+    healthcheck:
+      test: curl http://127.0.0.1:8080/admin/v2/namespaces/public/default


### PR DESCRIPTION
- Adds compose healthcheck that invokes the admin namespace API for the `/public/default` namespace.

Without this change, we are seeing random failures due to `"Namespace not found"`.

With this change, the server will not be put in the ready state until the `/public/default` namespace has been created. 