### PR TITLE
Smoke test for issue with JPA call from init method

### DIFF
--- a/data/data-jpa/src/main/java/com/example/data/jpa/AppInitializer.java
+++ b/data/data-jpa/src/main/java/com/example/data/jpa/AppInitializer.java
@@ -1,0 +1,20 @@
+package com.example.data.jpa;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AppInitializer implements InitializingBean {
+
+	private AuthorRepository authorRepository;
+
+	public AppInitializer(AuthorRepository authorRepository) {
+		this.authorRepository = authorRepository;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		authorRepository.findByNameContainingIgnoreCase("name");
+	}
+
+}


### PR DESCRIPTION
Hibernate queries do not work when called from `afterPropertiesSet()` with native image.

This adds a smoke test to check for that.

See https://github.com/oracle/graalvm-reachability-metadata/issues/324