### PR TITLE
Update Datastax Cassandra driver to 4.17.0 (fix nativeCompile)

### DIFF
--- a/data/data-cassandra-reactive/build.gradle
+++ b/data/data-cassandra-reactive/build.gradle
@@ -9,6 +9,11 @@ dependencies {
 	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
 	implementation("org.springframework.boot:spring-boot-starter-data-cassandra-reactive")
 
+	// The workaround for Spring Data Cassandra Reactive 4.1.x users to use 'nativeCompile'
+	constraints {
+		implementation('com.datastax.oss:java-driver-core:4.17.0')
+	}
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 
 	appTestImplementation(project(":aot-smoke-test-support"))

--- a/data/data-cassandra/build.gradle
+++ b/data/data-cassandra/build.gradle
@@ -9,6 +9,11 @@ dependencies {
 	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
 	implementation("org.springframework.boot:spring-boot-starter-data-cassandra")
 
+	// The workaround for Spring Data Cassandra 4.1.x users to use 'nativeCompile'
+	constraints {
+		implementation('com.datastax.oss:java-driver-core:4.17.0')
+	}
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 
 	appTestImplementation(project(":aot-smoke-test-support"))


### PR DESCRIPTION
This change overrides the Datastax Cassandra driver from `4.15.0` to `4.17.0` to pickup the fix and verify the fix for https://github.com/datastax/java-driver/pull/1674/files which allows `nativeCompile` to succeed for Spring Data Cassandra.

**NOTE**: The driver will **not** be updated in the SDC `4.1.x` line - but rather in the `4.2.x` line (see https://github.com/spring-projects/spring-data-cassandra/issues/1416). This means this change in the `3.1.x` smoke tests represents and verifies the **workaround** (not the **fix**) for `SDC 4.1.x` users. 
As such, it will make the SDC smoke tests go 🟢 but we should document this workaround in SDC docs somewhere (@christophstrobl wdyt?).

In SB 3.1.x the relevant dependency tree/chain is as follows:
> [SB 3.1.x](https://github.com/spring-projects/spring-boot/blob/65bc351847695c95ceb69292631e56993a6939f0/spring-boot-project/spring-boot-dependencies/build.gradle#L156-L164) -> Datastax Cassandra driver `4.15.0`
>
> [SB 3.1.x](https://github.com/spring-projects/spring-boot/blob/65bc351847695c95ceb69292631e56993a6939f0/spring-boot-project/spring-boot-dependencies/build.gradle#L1389C1-L1394) -> [SD bom 2023.0.2](https://mvnrepository.com/artifact/org.springframework.data/spring-data-bom/2023.0.2) -> [SDC 4.1.2](https://mvnrepository.com/artifact/org.springframework.data/spring-data-cassandra/4.1.2) -> Datastax Cassandra driver `4.15.0`

