### PR TITLE
Update Spring Pulsar to 0.2.1-SNAPSHOT

### DIFF
--- a/cloud/cloud-stream-pulsar/build.gradle
+++ b/cloud/cloud-stream-pulsar/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 ext {
 	set("springCloudVersion", "2022.0.2-SNAPSHOT")
-	set("springPulsarVersion", "0.1.1-SNAPSHOT")
+	set("springPulsarVersion", "0.2.1-SNAPSHOT")
 }
 
 dependencies {

--- a/integration/spring-pulsar-reactive/build.gradle
+++ b/integration/spring-pulsar-reactive/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-	set("springPulsarVersion", "0.1.1-SNAPSHOT")
+	set("springPulsarVersion", "0.2.1-SNAPSHOT")
 }
 
 repositories {

--- a/integration/spring-pulsar/build.gradle
+++ b/integration/spring-pulsar/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-	set("springPulsarVersion", "0.1.1-SNAPSHOT")
+	set("springPulsarVersion", "0.2.1-SNAPSHOT")
 }
 
 dependencies {


### PR DESCRIPTION
There is a fix in [Spring Pulsar 0.2.1-SNAPSHOT](https://github.com/spring-projects/spring-pulsar/pull/429) queued up which allows using GraalVM 23.1.0-dev to build native images.

**[NOTE]** This can be merged before the Spring Pulsar PR - it just will not go green until the other PR is merged.

cc: @sdeleuze 