### PR TITLE
Update Spring Pulsar (Boot 3.2.0 compatible)

### DIFF
--- a/cloud/cloud-stream-pulsar/build.gradle
+++ b/cloud/cloud-stream-pulsar/build.gradle
@@ -5,17 +5,18 @@ plugins {
 	id "org.graalvm.buildtools.native"
 }
 
-ext {
-	set("springPulsarVersion", "0.2.1-SNAPSHOT")
-}
-
 dependencies {
 	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
 	implementation(platform("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"))
 	implementation("org.springframework.boot:spring-boot-starter")
 	implementation("org.springframework.cloud:spring-cloud-stream")
-	implementation("org.springframework.pulsar:spring-pulsar-spring-boot-starter:${springPulsarVersion}")
-	implementation("org.springframework.pulsar:spring-pulsar-spring-cloud-stream-binder:${springPulsarVersion}")
+	// TODO remove version once https://github.com/spring-cloud/spring-cloud-stream/pull/2816 is merged
+	implementation("org.springframework.cloud:spring-cloud-stream-binder-pulsar:4.1.0-SNAPSHOT")
+	implementation("org.springframework.boot:spring-boot-starter-pulsar")
+	// TODO remove constraints once Boot goes back to snapshots
+	constraints {
+		implementation('org.springframework.pulsar:spring-pulsar:1.0.0-SNAPSHOT')
+	}
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 

--- a/cloud/cloud-stream-pulsar/docker-compose.yml
+++ b/cloud/cloud-stream-pulsar/docker-compose.yml
@@ -1,6 +1,7 @@
+version: '3'
 services:
   pulsar:
-    image: apachepulsar/pulsar:2.11.0
+    image: apachepulsar/pulsar:3.1.0
     ports:
       - '8080'
       - '6650'

--- a/cloud/cloud-stream-pulsar/src/main/resources/application.yml
+++ b/cloud/cloud-stream-pulsar/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring.main.web-application-type: none
 spring.pulsar:
   client:
     service-url: "pulsar://${PULSAR_HOST:localhost}:${PULSAR_PORT_6650:6650}"
-  administration:
+  admin:
     service-url: "http://${PULSAR_HOST:localhost}:${PULSAR_PORT_8080:8080}"
 
 spring.cloud:

--- a/integration/spring-pulsar-reactive/build.gradle
+++ b/integration/spring-pulsar-reactive/build.gradle
@@ -5,17 +5,22 @@ plugins {
 	id "org.graalvm.buildtools.native"
 }
 
-ext {
-	set("springPulsarVersion", "0.2.1-SNAPSHOT")
-}
-
 repositories {
 	maven { url "https://repository.apache.org/content/repositories/snapshots" }
 }
 
 dependencies {
 	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
-	implementation("org.springframework.pulsar:spring-pulsar-reactive-spring-boot-starter:${springPulsarVersion}")
+
+	implementation("org.springframework.boot:spring-boot-starter-pulsar-reactive")
+	constraints {
+		// TODO remove once Boot goes back to snapshots
+		implementation("org.springframework.pulsar:spring-pulsar:1.0.0-SNAPSHOT")
+		implementation("org.springframework.pulsar:spring-pulsar-reactive:1.0.0-SNAPSHOT")
+		// TODO remove once reactive client releases 0.4.0 goes back to snapshots
+		implementation("org.apache.pulsar:pulsar-client-reactive-adapter:0.3.1-SNAPSHOT")
+		implementation("org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:0.3.1-SNAPSHOT")
+	}
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 

--- a/integration/spring-pulsar-reactive/docker-compose.yml
+++ b/integration/spring-pulsar-reactive/docker-compose.yml
@@ -1,6 +1,7 @@
+version: '3'
 services:
   pulsar:
-    image: apachepulsar/pulsar:2.11.0
+    image: apachepulsar/pulsar:3.1.0
     ports:
       - '8080'
       - '6650'

--- a/integration/spring-pulsar-reactive/src/main/resources/application.properties
+++ b/integration/spring-pulsar-reactive/src/main/resources/application.properties
@@ -1,2 +1,8 @@
 spring.pulsar.client.service-url=pulsar://${PULSAR_HOST:localhost}:${PULSAR_PORT_6650:6650}
-spring.pulsar.administration.service-url=http://${PULSAR_HOST:localhost}:${PULSAR_PORT_8080:8080}
+spring.pulsar.admin.service-url=http://${PULSAR_HOST:localhost}:${PULSAR_PORT_8080:8080}
+
+logging.level.root=INFO
+logging.level.org.apache.pulsar=WARN
+logging.level.org.apache.pulsar.common.util.netty.DnsResolverUtil=ERROR
+logging.level.org.springframework.pulsar=DEBUG
+logging.level.org.springframework.pulsar.function=WARN

--- a/integration/spring-pulsar/build.gradle
+++ b/integration/spring-pulsar/build.gradle
@@ -5,13 +5,14 @@ plugins {
 	id "org.graalvm.buildtools.native"
 }
 
-ext {
-	set("springPulsarVersion", "0.2.1-SNAPSHOT")
-}
-
 dependencies {
 	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
-	implementation("org.springframework.pulsar:spring-pulsar-spring-boot-starter:${springPulsarVersion}")
+
+	implementation("org.springframework.boot:spring-boot-starter-pulsar")
+	// TODO remove once Boot goes back to snapshots
+	constraints {
+		implementation('org.springframework.pulsar:spring-pulsar:1.0.0-SNAPSHOT')
+	}
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 

--- a/integration/spring-pulsar/docker-compose.yml
+++ b/integration/spring-pulsar/docker-compose.yml
@@ -1,6 +1,7 @@
+version: '3'
 services:
   pulsar:
-    image: apachepulsar/pulsar:2.11.0
+    image: apachepulsar/pulsar:3.1.0
     ports:
       - '8080'
       - '6650'

--- a/integration/spring-pulsar/src/main/resources/application.properties
+++ b/integration/spring-pulsar/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.pulsar.client.service-url=pulsar://${PULSAR_HOST:localhost}:${PULSAR_PORT_6650:6650}
-spring.pulsar.administration.service-url=http://${PULSAR_HOST:localhost}:${PULSAR_PORT_8080:8080}
+spring.pulsar.admin.service-url=http://${PULSAR_HOST:localhost}:${PULSAR_PORT_8080:8080}


### PR DESCRIPTION
The Spring Pulsar test suites were still using the legacy starter (v0.2.0) and also Pulsar 2.11.0.
This commit updates to the latest versions that are compatible w/ Boot 3.2.0

<img src="https://github.com/spring-projects/spring-aot-smoke-tests/assets/28907971/b192f736-f337-420f-aa01-abb28dbdd80a" width=100 height=100/>

This will not pass until the `0.3.1-SNAPSHOT` version of the reactive client is published (should be soon). 
