### PR TITLE
Add smoketests for relevant Neo4j features.

### DIFF
--- a/STATUS.adoc
+++ b/STATUS.adoc
@@ -360,6 +360,12 @@ h|nativeTest
 |
 |
 
+|data-neo4j
+|image:https://ci.spring.io/api/v1/teams/spring-aot-smoke-tests/pipelines/spring-aot-smoke-tests-3.2.x/jobs/data-neo4j-app-test/badge[link=https://ci.spring.io/teams/spring-aot-smoke-tests/pipelines/spring-aot-smoke-tests-3.2.x/jobs/data-neo4j-app-test]
+|image:https://ci.spring.io/api/v1/teams/spring-aot-smoke-tests/pipelines/spring-aot-smoke-tests-3.2.x/jobs/data-neo4j-native-app-test/badge[link=https://ci.spring.io/teams/spring-aot-smoke-tests/pipelines/spring-aot-smoke-tests-3.2.x/jobs/data-neo4j-native-app-test]
+|
+|
+
 |data-r2dbc
 |image:https://ci.spring.io/api/v1/teams/spring-aot-smoke-tests/pipelines/spring-aot-smoke-tests-3.2.x/jobs/data-r2dbc-app-test/badge[link=https://ci.spring.io/teams/spring-aot-smoke-tests/pipelines/spring-aot-smoke-tests-3.2.x/jobs/data-r2dbc-app-test]
 |image:https://ci.spring.io/api/v1/teams/spring-aot-smoke-tests/pipelines/spring-aot-smoke-tests-3.2.x/jobs/data-r2dbc-native-app-test/badge[link=https://ci.spring.io/teams/spring-aot-smoke-tests/pipelines/spring-aot-smoke-tests-3.2.x/jobs/data-r2dbc-native-app-test]

--- a/ci/smoke-tests.yml
+++ b/ci/smoke-tests.yml
@@ -163,6 +163,9 @@ groups:
      - name: data-mongodb-reactive
        app_test: true
        test: false
+     - name: data-neo4j
+       app_test: true
+       test: false
      - name: data-r2dbc
        app_test: true
        test: false

--- a/data/data-neo4j/README.adoc
+++ b/data/data-neo4j/README.adoc
@@ -1,0 +1,1 @@
+Tests if Spring Data Neo4j works

--- a/data/data-neo4j/build.gradle
+++ b/data/data-neo4j/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+	id "java"
+	id "org.springframework.boot"
+	id "org.springframework.aot.smoke-test"
+	id "org.graalvm.buildtools.native"
+}
+
+dependencies {
+	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+	implementation("org.springframework.boot:spring-boot-starter-data-neo4j")
+	implementation("io.projectreactor:reactor-core")
+
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+	appTestImplementation(project(":aot-smoke-test-support"))
+	appTestImplementation("org.awaitility:awaitility:4.2.0")
+}

--- a/data/data-neo4j/docker-compose.yml
+++ b/data/data-neo4j/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  neo4j:
+    image: 'neo4j:5'
+    ports:
+      - '7687'
+    expose:
+      - '7687'
+    hostname: 'neo4j'
+    container_name: 'neo4j'
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider localhost:7474 || exit 1" ]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    environment:
+      - NEO4J_AUTH=neo4j/verysecret

--- a/data/data-neo4j/src/appTest/java/neo4j/DataNeo4jApplicationAotTests.java
+++ b/data/data-neo4j/src/appTest/java/neo4j/DataNeo4jApplicationAotTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.smoketest.support.assertj.AssertableOutput;
+import org.springframework.aot.smoketest.support.junit.ApplicationTest;
+
+@ApplicationTest
+class DataNeo4jApplicationAotTests {
+
+	@Test
+	void annotatedTypesShouldHaveBeenRegistered(AssertableOutput output) {
+		var expectedLines = List.of("All types are present: ChildNode",
+				"Id has been populated from DB: \\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}");
+
+		assertExpectedLines(output, expectedLines);
+	}
+
+	@Test
+	void externallyGeneratedFieldsShouldBePopulated(AssertableOutput output) {
+		var expectedLines = List.of("Generated id is present: \\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}",
+				"CreatedAt is present: true", "CreatedBy is present: true", "UpdatedAt is absent: false",
+				"UpdatedBy is absent: false", "Version is 0", "UpdatedAt is now present: true",
+				"UpdatedBy is now present: true", "Version is now 1");
+
+		assertExpectedLines(output, expectedLines);
+	}
+
+	@Test
+	void internallyGeneratedIdsShouldBePopulated(AssertableOutput output) {
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			assertThat(output).hasLineMatching("Internal element id is present: \\d:[\\w\\-]+:\\d")
+				.hasLineMatching("\\[Reactive\\] Internal element id is present: \\d:[\\w\\-]+:\\d");
+		});
+	}
+
+	@Test
+	void cypherDSLIntegrationShouldWork(AssertableOutput output) {
+		var expectedLines = List.of("Loaded 1 movies", "With 1 actors, first named An Actor");
+
+		assertExpectedLines(output, expectedLines);
+	}
+
+	private static void assertExpectedLines(AssertableOutput output, List<String> expectedLines) {
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			expectedLines.forEach(line -> assertThat(output).hasLineMatching(line));
+			expectedLines.forEach(line -> assertThat(output).hasLineMatching("\\[Reactive\\] " + line));
+		});
+	}
+
+	@Test
+	void qbeShouldWork(AssertableOutput output) {
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			assertThat(output).hasLineMatching("Found one movie by example with id \\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}")
+				.hasLineMatching(
+						"\\[Reactive\\] Found one movie by example with id \\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}");
+		});
+	}
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/DataNeo4jApplication.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/DataNeo4jApplication.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.neo4j;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.neo4j.cypherdsl.core.renderer.Configuration;
+import org.neo4j.cypherdsl.core.renderer.Dialect;
+import org.neo4j.driver.Driver;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.domain.ReactiveAuditorAware;
+import org.springframework.data.neo4j.config.EnableNeo4jAuditing;
+import org.springframework.data.neo4j.config.EnableReactiveNeo4jAuditing;
+import org.springframework.data.neo4j.core.DatabaseSelectionProvider;
+import org.springframework.data.neo4j.core.ReactiveDatabaseSelectionProvider;
+import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
+import org.springframework.data.neo4j.core.transaction.ReactiveNeo4jTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import reactor.core.publisher.Mono;
+
+@SpringBootApplication
+@EnableNeo4jAuditing(auditorAwareRef = "fixedAuditor", dateTimeProviderRef = "fixedTime")
+@EnableReactiveNeo4jAuditing(auditorAwareRef = "reactiveFixedAuditor", dateTimeProviderRef = "fixedTime")
+public class DataNeo4jApplication {
+
+	public static final LocalDateTime FIXED_DATE = LocalDateTime.of(2023, 9, 21, 7, 0, 0, 0);
+
+	public static void main(String[] args) throws InterruptedException {
+		SpringApplication.run(DataNeo4jApplication.class, args);
+		Thread.currentThread().join(); // To be able to measure memory consumption
+	}
+
+	@Bean
+	AuditorAware<String> fixedAuditor() {
+		return () -> Optional.of("Some person");
+	}
+
+	@Bean
+	ReactiveAuditorAware<String> reactiveFixedAuditor() {
+		return () -> Mono.just("Some person");
+	}
+
+	@Bean
+	DateTimeProvider fixedTime() {
+		return () -> Optional.of(FIXED_DATE);
+	}
+
+	@Bean
+	Configuration cypherDslConfiguration() {
+		return Configuration.newConfig().withDialect(Dialect.NEO4J_5).build();
+	}
+
+	@Bean
+	public PlatformTransactionManager transactionManager(Driver driver,
+			DatabaseSelectionProvider databaseNameProvider) {
+		return new Neo4jTransactionManager(driver, databaseNameProvider);
+	}
+
+	@Bean
+	public ReactiveNeo4jTransactionManager reactiveTransactionManager(Driver driver,
+			ReactiveDatabaseSelectionProvider databaseNameProvider) {
+		return new ReactiveNeo4jTransactionManager(driver, databaseNameProvider);
+	}
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/DatabaseInitializer.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/DatabaseInitializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.neo4j;
+
+import org.neo4j.driver.Driver;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseInitializer implements SmartLifecycle {
+
+	private final Driver driver;
+
+	private boolean running;
+
+	public DatabaseInitializer(Driver driver) {
+		this.driver = driver;
+	}
+
+	@Override
+	public void start() {
+		if (running) {
+			return;
+		}
+
+		try (var session = driver.session(); var tx = session.beginTransaction()) {
+			tx.run("MATCH (n:ParentLabel:ChildLabel) DETACH DELETE n");
+			tx.run("CREATE (:ParentLabel:ChildLabel {id: randomUuid(), name: 'BothLabelsMustBeManagedTypes'})");
+			tx.run("CREATE (:Movie {id: randomUuid(), version: 0, title: 'A movie', updatedBy: 'A person', updatedAt: localdatetime()}) <-[:ACTED_IN]-(:Person {name: 'An Actor'})");
+			tx.commit();
+			this.running = true;
+		}
+	}
+
+	@Override
+	public void stop() {
+	}
+
+	@Override
+	public boolean isRunning() {
+		return running;
+	}
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/ImperativeTestRunner.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/ImperativeTestRunner.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.neo4j;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.neo4j.cypherdsl.core.Cypher;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.data.domain.Example;
+import org.springframework.data.neo4j.core.Neo4jTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Component
+public class ImperativeTestRunner implements CommandLineRunner {
+
+	private final Neo4jTemplate neo4jTemplate;
+
+	private final TransactionTemplate transactionTemplate;
+
+	private final MovieRepository movieRepository;
+
+	public ImperativeTestRunner(Neo4jTemplate neo4jTemplate, TransactionTemplate transactionTemplate,
+			MovieRepository movieRepository) {
+		this.neo4jTemplate = neo4jTemplate;
+		this.transactionTemplate = transactionTemplate;
+		this.movieRepository = movieRepository;
+	}
+
+	@Override
+	public void run(String... args) {
+
+		annotatedTypesShouldHaveBeenRegistered();
+		externallyGeneratedFieldsShouldBePopulated();
+		internallyGeneratedIdsShouldBePopulated();
+		cypherDSLIntegrationShouldWork();
+		qbeShouldWork();
+	}
+
+	private void qbeShouldWork() {
+
+		log("---- Neo4j Query By Example (QBE) ----");
+		var optionalMovie = movieRepository.findOne(Example.of(new Movie("A movie")));
+		optionalMovie.ifPresent((movie) -> {
+			log("Found one movie by example with id %s", movie.getId());
+		});
+	}
+
+	private void cypherDSLIntegrationShouldWork() {
+
+		log("---- Neo4j Cypher-DSL integration and relationship population ----");
+		var title = Cypher.node("Movie").named("movie").property("title");
+		var movies = new ArrayList<>(movieRepository.findAll(title.contains(Cypher.literalOf("A movie"))));
+
+		log("Loaded %d movies", movies.size());
+		if (!(movies.isEmpty() || movies.get(0).getActors().isEmpty())) {
+			log("With %s actors, first named %s", movies.get(0).getActors().size(),
+					movies.get(0).getActors().get(0).getName());
+		}
+	}
+
+	private void internallyGeneratedIdsShouldBePopulated() {
+
+		log("---- Neo4j internally generated values ----");
+		var person = new Person();
+		person.setName("Jane Doe");
+		person = neo4jTemplate.save(person);
+		log("Internal element id is present: %s", person.getId());
+	}
+
+	private void externallyGeneratedFieldsShouldBePopulated() {
+
+		log("---- Neo4j externally generated values ----");
+		var movie = transactionTemplate
+			.execute(tx -> movieRepository.save(new Movie("One Flew Over the Cuckoos Nest")));
+
+		log("Generated id is present: %s", movie.getId());
+		log("CreatedAt is present: %s", DataNeo4jApplication.FIXED_DATE.equals(movie.getCreatedAt()));
+		log("CreatedBy is present: %s", "Some person".equals(movie.getCreatedBy()));
+		log("UpdatedAt is absent: %s", movie.getUpdatedAt() == null);
+		log("UpdatedBy is absent: %s", movie.getUpdatedBy() == null);
+		log("Version is %d", movie.getVersion());
+
+		movie.setTitle("One Flew Over the Cuckoo's Nest");
+		var updatedMovie = transactionTemplate.execute(tx -> movieRepository.save(movie));
+
+		log("UpdatedAt is now present: %s", DataNeo4jApplication.FIXED_DATE.equals(updatedMovie.getUpdatedAt()));
+		log("UpdatedBy is now present: %s", "Some person".equals(updatedMovie.getUpdatedBy()));
+		log("Version is now %d", updatedMovie.getVersion());
+	}
+
+	private void annotatedTypesShouldHaveBeenRegistered() {
+
+		log("---- Neo4j Managed types ----");
+
+		var optionalResult = this.neo4jTemplate.findOne("MATCH (t:ParentLabel {name: $name}) RETURN t",
+				Map.of("name", "BothLabelsMustBeManagedTypes"), ParentNode.class);
+		optionalResult.ifPresent(node -> {
+
+			log("All types are present: %s", node.getClass().getSimpleName());
+			log("Id has been populated from DB: %s", node.getId());
+		});
+	}
+
+	private void log(Object value) {
+		log(String.valueOf(value), new Object[0]);
+	}
+
+	private void log(String message, Object... arguments) {
+		String messageNewline = String.valueOf(message).endsWith("\n") ? message : message + "\n";
+		System.out.printf(messageNewline, arguments);
+		System.out.flush();
+	}
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/Movie.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/Movie.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.neo4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.PersistenceCreator;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+@Node
+public class Movie {
+
+	@Id
+	@GeneratedValue
+	private final UUID id;
+
+	@Version
+	private final Long version;
+
+	private String title;
+
+	@Relationship(direction = Relationship.Direction.INCOMING, type = "ACTED_IN")
+	private final List<Person> actors;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@CreatedBy
+	private String createdBy;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	@LastModifiedBy
+	private String updatedBy;
+
+	public Movie(String title) {
+		this(null, null, title, null, null, null, null, null);
+	}
+
+	@PersistenceCreator
+	Movie(UUID id, Long version, String title, List<Person> actors, LocalDateTime createdAt, String createdBy,
+			LocalDateTime updatedAt, String updatedBy) {
+		this.id = id;
+		this.version = version;
+		this.title = title;
+		this.actors = actors;
+		this.createdAt = createdAt;
+		this.createdBy = createdBy;
+		this.updatedAt = updatedAt;
+		this.updatedBy = updatedBy;
+	}
+
+	public UUID getId() {
+		return id;
+	}
+
+	public Long getVersion() {
+		return version;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public List<Person> getActors() {
+		return actors;
+	}
+
+	public LocalDateTime getCreatedAt() {
+		return createdAt;
+	}
+
+	public String getCreatedBy() {
+		return createdBy;
+	}
+
+	public LocalDateTime getUpdatedAt() {
+		return updatedAt;
+	}
+
+	public String getUpdatedBy() {
+		return updatedBy;
+	}
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/MovieRepository.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/MovieRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.neo4j;
+
+import java.util.UUID;
+
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.support.CypherdslConditionExecutor;
+import org.springframework.data.repository.query.QueryByExampleExecutor;
+
+public interface MovieRepository
+		extends Neo4jRepository<Movie, UUID>, CypherdslConditionExecutor<Movie>, QueryByExampleExecutor<Movie> {
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/ParentNode.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/ParentNode.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.data.neo4j;
+
+import java.util.UUID;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * This class is used to ensure managed types are registered properly. There must not be a
+ * repository that references {@link ChildNode}, otherwise they will trigger the type
+ * registration for that type.
+ */
+@Node("ParentLabel")
+public abstract sealed class ParentNode permits ParentNode.ChildNode {
+
+	@Id
+	@GeneratedValue
+	private UUID id;
+
+	private String name;
+
+	public UUID getId() {
+		return this.id;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Node("ChildLabel")
+	public static final class ChildNode extends ParentNode {
+
+	}
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/Person.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/Person.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.neo4j;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+
+public class Person {
+
+	@Id
+	@GeneratedValue
+	private String id;
+
+	private String name;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/ReactiveMovieRepository.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/ReactiveMovieRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.neo4j;
+
+import java.util.UUID;
+
+import org.springframework.data.neo4j.repository.ReactiveNeo4jRepository;
+import org.springframework.data.neo4j.repository.support.ReactiveCypherdslConditionExecutor;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+
+public interface ReactiveMovieRepository extends ReactiveNeo4jRepository<Movie, UUID>,
+		ReactiveCypherdslConditionExecutor<Movie>, ReactiveQueryByExampleExecutor<Movie> {
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/ReactiveTestRunner.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/ReactiveTestRunner.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.neo4j;
+
+import java.util.Map;
+
+import org.neo4j.cypherdsl.core.Cypher;
+import org.neo4j.driver.Driver;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.data.domain.Example;
+import org.springframework.data.neo4j.core.ReactiveNeo4jTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+@Component
+public class ReactiveTestRunner implements CommandLineRunner {
+
+	private final Driver driver;
+
+	private final ReactiveNeo4jTemplate neo4jTemplate;
+
+	private final TransactionalOperator transactionalOperator;
+
+	private final ReactiveMovieRepository movieRepository;
+
+	public ReactiveTestRunner(Driver driver, ReactiveNeo4jTemplate neo4jTemplate,
+			ReactiveTransactionManager reactiveTransactionManager, ReactiveMovieRepository movieRepository) {
+		this.driver = driver;
+		this.neo4jTemplate = neo4jTemplate;
+		this.transactionalOperator = TransactionalOperator.create(reactiveTransactionManager);
+		this.movieRepository = movieRepository;
+	}
+
+	@Override
+	public void run(String... args) throws Exception {
+
+		annotatedTypesShouldHaveBeenRegistered();
+		externallyGeneratedFieldsShouldBePopulated();
+		internallyGeneratedIdsShouldBePopulated();
+		cypherDSLIntegrationShouldWork();
+		qbeShouldWork();
+	}
+
+	private void qbeShouldWork() {
+
+		log("---- [Reactive] Neo4j Query By Example (QBE) ----");
+		var optionalMovie = movieRepository.findOne(Example.of(new Movie("A movie"))).blockOptional();
+		optionalMovie.ifPresent((movie) -> {
+			log("[Reactive] Found one movie by example with id %s", movie.getId());
+		});
+	}
+
+	private void cypherDSLIntegrationShouldWork() {
+
+		log("---- [Reactive] Neo4j Cypher-DSL integration and relationship population ----");
+		var title = Cypher.node("Movie").named("movie").property("title");
+		var movies = movieRepository.findAll(title.contains(Cypher.literalOf("A movie"))).collectList().block();
+
+		log("[Reactive] Loaded %d movies", movies.size());
+		if (!(movies.isEmpty() || movies.get(0).getActors().isEmpty())) {
+			log("[Reactive] With %s actors, first named %s", movies.get(0).getActors().size(),
+					movies.get(0).getActors().get(0).getName());
+		}
+	}
+
+	private void internallyGeneratedIdsShouldBePopulated() {
+
+		log("---- [Reactive] Neo4j internally generated values ----");
+		var person = new Person();
+		person.setName("Jane Doe");
+		person = neo4jTemplate.save(person).block();
+		log("[Reactive] Internal element id is present: %s", person.getId());
+	}
+
+	private void externallyGeneratedFieldsShouldBePopulated() {
+
+		log("---- [Reactive] Neo4j externally generated values ----");
+		var movie = movieRepository.save(new Movie("One Flew Over the Cuckoos Nest"))
+			.as(transactionalOperator::transactional)
+			.block();
+
+		log("[Reactive] Generated id is present: %s", movie.getId());
+		log("[Reactive] CreatedAt is present: %s", DataNeo4jApplication.FIXED_DATE.equals(movie.getCreatedAt()));
+		log("[Reactive] CreatedBy is present: %s", "Some person".equals(movie.getCreatedBy()));
+		log("[Reactive] UpdatedAt is absent: %s", movie.getUpdatedAt() == null);
+		log("[Reactive] UpdatedBy is absent: %s", movie.getUpdatedBy() == null);
+		log("[Reactive] Version is %d", movie.getVersion());
+
+		movie.setTitle("One Flew Over the Cuckoo's Nest");
+		var updatedMovie = movieRepository.save(movie).as(transactionalOperator::transactional).block();
+
+		log("[Reactive] UpdatedAt is now present: %s",
+				DataNeo4jApplication.FIXED_DATE.equals(updatedMovie.getUpdatedAt()));
+		log("[Reactive] UpdatedBy is now present: %s", "Some person".equals(updatedMovie.getUpdatedBy()));
+		log("[Reactive] Version is now %d", updatedMovie.getVersion());
+	}
+
+	private void annotatedTypesShouldHaveBeenRegistered() {
+
+		log("---- [Reactive] Neo4j Managed types ----");
+
+		var optionalResult = this.neo4jTemplate
+			.findOne("MATCH (t:ParentLabel {name: $name}) RETURN t", Map.of("name", "BothLabelsMustBeManagedTypes"),
+					ParentNode.class)
+			.blockOptional();
+		optionalResult.ifPresent(node -> {
+
+			log("[Reactive] All types are present: %s", node.getClass().getSimpleName());
+			log("[Reactive] Id has been populated from DB: %s", node.getId());
+		});
+	}
+
+	private void initializeDatabase(String... args) {
+		try (var session = driver.session(); var tx = session.beginTransaction()) {
+			tx.run("MATCH (n:ParentLabel:ChildLabel) DETACH DELETE n");
+			tx.run("CREATE (:ParentLabel:ChildLabel {id: randomUuid(), name: 'BothLabelsMustBeManagedTypes'})");
+			tx.run("CREATE (:Movie {id: randomUuid(), version: 0, title: 'A movie', updatedBy: 'A person', updatedAt: localdatetime()}) <-[:ACTED_IN]-(:Person {name: 'An Actor'})");
+			tx.commit();
+		}
+	}
+
+	private void log(Object value) {
+		log(String.valueOf(value), new Object[0]);
+	}
+
+	private void log(String message, Object... arguments) {
+		String messageNewline = String.valueOf(message).endsWith("\n") ? message : message + "\n";
+		System.out.printf(messageNewline, arguments);
+		System.out.flush();
+	}
+
+}

--- a/data/data-neo4j/src/main/java/com/example/data/neo4j/WorkaroundsForMissingTypeHintsAndSB37574Config.java
+++ b/data/data-neo4j/src/main/java/com/example/data/neo4j/WorkaroundsForMissingTypeHintsAndSB37574Config.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.neo4j;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.boot.autoconfigure.domain.EntityScanner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.data.neo4j.aot.Neo4jManagedTypes;
+import org.springframework.data.neo4j.core.convert.Neo4jConversions;
+import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.RelationshipProperties;
+import org.springframework.data.neo4j.repository.query.CypherdslConditionExecutorImpl;
+import org.springframework.data.neo4j.repository.query.ReactiveCypherdslConditionExecutorImpl;
+
+/**
+ * See https://github.com/spring-projects/spring-data-neo4j/issues/2798 Only needed until
+ * https://github.com/spring-projects/spring-boot/pull/37574 is resolved Otherwise the
+ * abscence of {@link ParentNode.ChildNode} will cause application startup failure
+ */
+@Configuration(proxyBeanMethods = false)
+@ImportRuntimeHints(WorkaroundsForMissingTypeHintsAndSB37574Config.MissingRuntimeHints.class)
+public class WorkaroundsForMissingTypeHintsAndSB37574Config {
+
+	@Bean
+	public Neo4jManagedTypes neo4jManagedTypes(ApplicationContext applicationContext) throws ClassNotFoundException {
+		Set<Class<?>> initialEntityClasses = new EntityScanner(applicationContext).scan(Node.class,
+				RelationshipProperties.class);
+		return Neo4jManagedTypes.fromIterable(initialEntityClasses);
+	}
+
+	@Bean
+	public Neo4jMappingContext neo4jMappingContext(Neo4jManagedTypes managedTypes, Neo4jConversions neo4jConversions) {
+
+		Neo4jMappingContext context = new Neo4jMappingContext(neo4jConversions);
+		context.setManagedTypes(managedTypes);
+		return context;
+	}
+
+	public static class MissingRuntimeHints implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			hints.reflection()
+				.registerTypes(
+						List.of(TypeReference.of(CypherdslConditionExecutorImpl.class),
+								TypeReference.of(ReactiveCypherdslConditionExecutorImpl.class)),
+						builder -> builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+								MemberCategory.INVOKE_PUBLIC_METHODS));
+		}
+
+	}
+
+}

--- a/data/data-neo4j/src/main/resources/application.properties
+++ b/data/data-neo4j/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.neo4j.uri=bolt://${NEO4J_HOST:localhost}:${NEO4J_PORT_7687:7687}
+spring.neo4j.authentication.username=neo4j
+spring.neo4j.authentication.password=verysecret


### PR DESCRIPTION
This adds a bunch of imperative and reactive tests for Spring Data Neo4j.
All of the tests require AoT hints.

I have included a class `WorkaroundsForMissingTypeHintsAndSB37574Config` which includes the workaround for https://github.com/spring-projects/spring-boot/pull/37574 as well as one more missing reflection hint on SDN site of things.

I'm opening this now with the workaround included to polish out everything that doesn't fit.
The workarounds can be deleted next Boot and Data releases.

We are happy to maintain this module.