### PR TITLE
Add Revved up by Develocity badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= Spring AOT Smoke Tests
+= Spring AOT Smoke Tests image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Develocity", link="https://ge.spring.io/scans?search.rootProjectNames=spring-aot-smoke-tests"]
 
 A suite of tests for applications using AOT on the JVM and in GraalVM native images.
 There are two types of tests: unit tests and application tests.


### PR DESCRIPTION
This pull request adds a badge to the project's README to indicate that it uses the Develocity instance hosted at https://ge.spring.io/.

Other Spring projects, such as [Spring Boot](https://github.com/spring-projects/spring-boot?tab=readme-ov-file#spring-boot---) and [Spring Framework](https://github.com/spring-projects/spring-framework?tab=readme-ov-file#-spring-framework--), already have the badge present in their README. 