### PR TITLE
Do not enforce snapshot for spring-plugin.

### DIFF
--- a/gradle/plugins/aot-smoke-test-plugin/src/main/java/org/springframework/aot/gradle/ForceSnapshots.java
+++ b/gradle/plugins/aot-smoke-test-plugin/src/main/java/org/springframework/aot/gradle/ForceSnapshots.java
@@ -16,6 +16,8 @@
 
 package org.springframework.aot.gradle;
 
+import java.util.Set;
+
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.ModuleVersionSelector;
@@ -42,6 +44,8 @@ import org.gradle.api.artifacts.ResolutionStrategy;
  */
 final class ForceSnapshots implements Action<DependencyResolveDetails> {
 
+	private static final Set<String> NO_SNAPSHOT = Set.of("org.springframework.boot", "org.springframework.cloud", "org.springframework.plugin");
+
 	@Override
 	public void execute(DependencyResolveDetails dependency) {
 		ModuleVersionSelector requested = dependency.getRequested();
@@ -50,8 +54,7 @@ final class ForceSnapshots implements Action<DependencyResolveDetails> {
 			return;
 		}
 		String group = requested.getGroup();
-		if (group.startsWith("org.springframework") && !group.equals("org.springframework.boot")
-				&& !group.equals("org.springframework.cloud")) {
+		if (group.startsWith("org.springframework") && !NO_SNAPSHOT.contains(group)) {
 			dependency.useVersion(snapshotOf(version));
 		}
 	}


### PR DESCRIPTION
`spring-plugin` does not provide snapshots for all versions and the tooling should not override dependencies originating from `spring-hateoas`.