### PR TITLE
Add test for data-redis Jackson2 backed hash mapper.

### DIFF
--- a/data/data-redis/src/appTest/java/com/example/data/redis/DataRedisApplicationAotTests.java
+++ b/data/data-redis/src/appTest/java/com/example/data/redis/DataRedisApplicationAotTests.java
@@ -41,6 +41,19 @@ class DataRedisApplicationAotTests {
 	}
 
 	@Test
+	void jackson2hashMapper(AssertableOutput output) {
+
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			assertThat(output).hasLineMatching("hash-mapper-default-raw: .*firstname=hashed-fn.*");
+			assertThat(output).hasSingleLineContaining(
+					"hash-mapper-default-mapped: Person{firstname='hashed-fn', lastname='hashed-ln'}");
+			assertThat(output).hasLineMatching("hash-mapper-flat-raw: .*firstname=hashed-fn.*");
+			assertThat(output).hasSingleLineContaining(
+					"hash-mapper-flat-mapped: Person{firstname='hashed-fn', lastname='hashed-ln'}");
+		});
+	}
+
+	@Test
 	void jsonSerializer(AssertableOutput output) {
 		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
 			assertThat(output)


### PR DESCRIPTION
Data Redis `HashMapper` relies on internal Jackson2 node `_value`.

Related to: spring-projects/spring-data-redis#2838 (Tests will break until resolved)