### PR TITLE
Adapt pattern to changes in spring-data.

### DIFF
--- a/data/data-rest-mongodb/src/appTest/java/com/example/data/rest/mongodb/DataRestMongoDbApplicationAotTests.java
+++ b/data/data-rest-mongodb/src/appTest/java/com/example/data/rest/mongodb/DataRestMongoDbApplicationAotTests.java
@@ -20,7 +20,7 @@ class DataRestMongoDbApplicationAotTests {
 	void indexHasLinks(WebTestClient client) {
 		client.get().uri("/").exchange().expectBody().jsonPath("$._links.persons.href").value((href) -> {
 			assertThat(href).asInstanceOf(InstanceOfAssertFactories.STRING)
-				.matches(Pattern.compile("http://localhost:\\d+/person\\{\\?page,size,sort}"));
+				.matches(Pattern.compile("http://localhost:\\d+/person\\{\\?page,size,sort\\*}"));
 		}).jsonPath("$._links.profile.href").value((href) -> {
 			assertThat(href).asInstanceOf(InstanceOfAssertFactories.STRING)
 				.matches(Pattern.compile("http://localhost:\\d+/profile"));


### PR DESCRIPTION
Fix pattern causing test in `data:data-rest-mongodb` to fail due to changes in `spring-data-commons`.

See: spring-projects/spring-data-commons#2531