### PR TITLE
Expect JPA smoke tests to fail when using Hibernate 6.5.0.CR1

### DIFF
--- a/data/data-jpa-entityscan/build.gradle
+++ b/data/data-jpa-entityscan/build.gradle
@@ -16,3 +16,16 @@ dependencies {
 	appTestImplementation(project(":aot-smoke-test-support"))
 	appTestImplementation("org.awaitility:awaitility:4.2.0")
 }
+
+aotSmokeTest {
+	nativeTest {
+		expectedToFail {
+			becauseOf "https://github.com/oracle/graalvm-reachability-metadata/issues/477"
+		}
+	}
+	nativeAppTest {
+		expectedToFail {
+			becauseOf "https://github.com/oracle/graalvm-reachability-metadata/issues/477"
+		}
+	}
+}

--- a/data/data-jpa-kotlin/build.gradle
+++ b/data/data-jpa-kotlin/build.gradle
@@ -20,3 +20,11 @@ dependencies {
 	appTestImplementation(project(":aot-smoke-test-support"))
 	appTestImplementation("org.awaitility:awaitility:4.2.0")
 }
+
+aotSmokeTest {
+	nativeAppTest {
+		expectedToFail {
+			becauseOf "https://github.com/oracle/graalvm-reachability-metadata/issues/477"
+		}
+	}
+}

--- a/data/data-jpa/build.gradle
+++ b/data/data-jpa/build.gradle
@@ -16,3 +16,16 @@ dependencies {
 	appTestImplementation(project(":aot-smoke-test-support"))
 	appTestImplementation("org.awaitility:awaitility:4.2.0")
 }
+
+aotSmokeTest {
+	nativeTest {
+		expectedToFail {
+			becauseOf "https://github.com/oracle/graalvm-reachability-metadata/issues/477"
+		}
+	}
+	nativeAppTest {
+		expectedToFail {
+			becauseOf "https://github.com/oracle/graalvm-reachability-metadata/issues/477"
+		}
+	}
+}


### PR DESCRIPTION
See: https://github.com/oracle/graalvm-reachability-metadata/issues/477