### PR TITLE
Make pulsar reactive test more robust (3.2.x branch)

### DIFF
--- a/cloud/cloud-stream-pulsar/src/main/resources/application.yml
+++ b/cloud/cloud-stream-pulsar/src/main/resources/application.yml
@@ -21,3 +21,8 @@ spring.cloud:
           producer:
             producer-name: graalSupplierOut
 # NOTE: The spring.cloud.stream.pulsar.bindings exercises ext binding props
+
+logging.level:
+  org.apache.pulsar.common.util.netty.DnsResolverUtil: ERROR
+  org.springframework.pulsar: DEBUG
+  org.springframework.pulsar.function: WARN

--- a/integration/spring-pulsar-reactive/src/appTest/java/com/example/pulsar/SpringPulsarReactiveApplicationAotTests.java
+++ b/integration/spring-pulsar-reactive/src/appTest/java/com/example/pulsar/SpringPulsarReactiveApplicationAotTests.java
@@ -16,7 +16,7 @@ public class SpringPulsarReactiveApplicationAotTests {
 	void reactivePulsarListenerMethodReceivesMessage(AssertableOutput output) {
 		Awaitility.await()
 			.atMost(Duration.ofSeconds(30))
-			.untilAsserted(() -> assertThat(output).hasSingleLineContaining("Message Received: sample-message-50"));
+			.untilAsserted(() -> assertThat(output).hasLineMatching(".*Message Received: sample-message-.*"));
 	}
 
 }

--- a/integration/spring-pulsar-reactive/src/main/java/com/example/pulsar/SpringPulsarReactiveApplication.java
+++ b/integration/spring-pulsar-reactive/src/main/java/com/example/pulsar/SpringPulsarReactiveApplication.java
@@ -1,6 +1,12 @@
 package com.example.pulsar;
 
+import java.time.Duration;
+
 import org.apache.pulsar.reactive.client.api.MessageSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
@@ -9,11 +15,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.pulsar.reactive.config.annotation.ReactivePulsarListener;
 import org.springframework.pulsar.reactive.core.ReactivePulsarTemplate;
 
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 @SpringBootApplication
 public class SpringPulsarReactiveApplication {
+
+	private static final Logger LOG = LoggerFactory.getLogger(SpringPulsarReactiveApplication.class);
 
 	public static void main(String[] args) {
 		SpringApplication.run(SpringPulsarReactiveApplication.class, args);
@@ -22,16 +27,17 @@ public class SpringPulsarReactiveApplication {
 	@Bean
 	ApplicationRunner sendMessageToTopicOnAppStartup(ReactivePulsarTemplate<String> reactivePulsarTemplate) {
 		String topic = "graalvm-demo-topic-reactive";
-		return args -> Flux.range(0, 100)
+		return args -> Flux.range(0, 10)
 			.map((i) -> MessageSpec.of("sample-message-" + i))
 			.as((msgs) -> reactivePulsarTemplate.send(topic, msgs))
+			.delaySubscription(Duration.ofSeconds(3L))
 			.subscribe();
 	}
 
 	@ReactivePulsarListener(subscriptionName = "graalvm-demo-subscription-reactive",
 			topics = "graalvm-demo-topic-reactive")
 	public Mono<Void> listenReactive(String message) {
-		System.out.println("Message Received: " + message);
+		LOG.info("Message Received: " + message);
 		return Mono.empty();
 	}
 

--- a/integration/spring-pulsar-reactive/src/main/resources/application.properties
+++ b/integration/spring-pulsar-reactive/src/main/resources/application.properties
@@ -1,8 +1,6 @@
 spring.pulsar.client.service-url=pulsar://${PULSAR_HOST:localhost}:${PULSAR_PORT_6650:6650}
 spring.pulsar.admin.service-url=http://${PULSAR_HOST:localhost}:${PULSAR_PORT_8080:8080}
 
-logging.level.root=INFO
-logging.level.org.apache.pulsar=WARN
 logging.level.org.apache.pulsar.common.util.netty.DnsResolverUtil=ERROR
 logging.level.org.springframework.pulsar=DEBUG
 logging.level.org.springframework.pulsar.function=WARN

--- a/integration/spring-pulsar/src/main/resources/application.properties
+++ b/integration/spring-pulsar/src/main/resources/application.properties
@@ -1,2 +1,6 @@
 spring.pulsar.client.service-url=pulsar://${PULSAR_HOST:localhost}:${PULSAR_PORT_6650:6650}
 spring.pulsar.admin.service-url=http://${PULSAR_HOST:localhost}:${PULSAR_PORT_8080:8080}
+
+logging.level.org.apache.pulsar.common.util.netty.DnsResolverUtil=ERROR
+logging.level.org.springframework.pulsar=DEBUG
+logging.level.org.springframework.pulsar.function=WARN


### PR DESCRIPTION
Make Pulsar reactive test more robust

This commit delays the subscription to the message Publisher
to ensure messages are not sent before the message consumer
is available.

Also makes log levels consistent across all Pulsar tests.