### PR TITLE
Add smoke test for Spring Data Commons Web Support

### DIFF
--- a/data/data-web-support/README.adoc
+++ b/data/data-web-support/README.adoc
@@ -1,0 +1,1 @@
+Tests if Spring Data Commons Web Support works.

--- a/data/data-web-support/build.gradle
+++ b/data/data-web-support/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id "java"
+    id "org.springframework.boot"
+    id "org.springframework.aot.smoke-test"
+    id "org.graalvm.buildtools.native"
+}
+
+repositories {
+    mavenLocal()
+}
+
+dependencies {
+    implementation(enforcedPlatform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.data:spring-data-commons")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    appTestImplementation(project(":aot-smoke-test-support"))
+    appTestImplementation("org.awaitility:awaitility:4.2.0")
+}
+
+aotSmokeTest {
+    webApplication = true
+}

--- a/data/data-web-support/src/appTest/java/com/example/data/web/DataWebApplicationAotTests.java
+++ b/data/data-web-support/src/appTest/java/com/example/data/web/DataWebApplicationAotTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.smoketest.support.junit.ApplicationTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@ApplicationTest
+public class DataWebApplicationAotTests {
+
+	@Test
+	void rendersPaged(WebTestClient client) {
+		client.get().uri("/paged").exchange().expectBody().jsonPath("page.size").value((size) -> {
+			assertThat(size).asInstanceOf(InstanceOfAssertFactories.INTEGER).isEqualTo(5);
+		}).jsonPath("page.totalPages").value((size) -> {
+			assertThat(size).asInstanceOf(InstanceOfAssertFactories.INTEGER).isEqualTo(20);
+		});
+	}
+
+	@Test
+	void rendersUnpaged(WebTestClient client) {
+		client.get().uri("/unpaged").exchange().expectBody().jsonPath("page.size").value((size) -> {
+			assertThat(size).asInstanceOf(InstanceOfAssertFactories.INTEGER).isEqualTo(5);
+		}).jsonPath("page.totalPages").value((size) -> {
+			assertThat(size).asInstanceOf(InstanceOfAssertFactories.INTEGER).isEqualTo(1);
+		});
+	}
+
+}

--- a/data/data-web-support/src/main/java/com/example/data/web/DataWebApplication.java
+++ b/data/data-web-support/src/main/java/com/example/data/web/DataWebApplication.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.data.web;
+
+import java.util.List;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
+public class DataWebApplication {
+
+	public static void main(String[] args) throws InterruptedException {
+		SpringApplication.run(DataWebApplication.class, args);
+		Thread.currentThread().join(); // To be able to measure memory consumption
+	}
+
+	@RestController
+	static class DefaultController {
+
+		@GetMapping("/paged")
+		public Page paged() {
+			return new PageImpl(List.of("spring", "data", "web", "support", "paged"), PageRequest.of(2, 5), 100);
+		}
+
+		@GetMapping("/unpaged")
+		public Page unpaged() {
+			return new PageImpl(List.of("spring", "data", "web", "support", "unpaged"), Pageable.unpaged(), 5);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Add tests to verify Jackson serialization of Page instances work using the PageModule.

See: spring-projects/spring-data-commons#3117 (will fail until resolved)