### PR TITLE
Revert "Disable Cloud smoke tests with Boot 3.4"

### DIFF
--- a/.github/workflows/3.4.x-cloud-cloud-config-client.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-config-client.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Config Client
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_config_client_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-config-server.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-config-server.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Config Server
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_config_server_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-discovery-consul.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-discovery-consul.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Discovery Consul
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_discovery_consul_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-discovery-eureka.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-discovery-eureka.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Discovery Eureka
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_discovery_eureka_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-discovery-zookeeper.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-discovery-zookeeper.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Discovery Zookeeper
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_discovery_zookeeper_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-function-web.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-function-web.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Function Web
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_function_web_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-function-webflux.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-function-webflux.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Function Webflux
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_function_webflux_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-gateway.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-gateway.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Gateway
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_gateway_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-loadbalancing-web.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-loadbalancing-web.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Loadbalancing Web
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_loadbalancing_web_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-loadbalancing-webflux.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-loadbalancing-webflux.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Loadbalancing Webflux
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_loadbalancing_webflux_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-openfeign.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-openfeign.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Openfeign
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_openfeign_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-stream-kafka-streams.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-stream-kafka-streams.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Stream Kafka Streams
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_stream_kafka_streams_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-stream-kafka.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-stream-kafka.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Stream Kafka
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_stream_kafka_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-stream-pulsar.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-stream-pulsar.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Stream Pulsar
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_stream_pulsar_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-stream-rabbit.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-stream-rabbit.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Stream Rabbit
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_stream_rabbit_app_test:

--- a/.github/workflows/3.4.x-cloud-cloud-task.yml
+++ b/.github/workflows/3.4.x-cloud-cloud-task.yml
@@ -1,5 +1,7 @@
 name: 3.4.x | Cloud Smoke Tests | Cloud Task
 on:
+  schedule:
+    - cron : '50 0 * * *'
   workflow_dispatch:
 jobs:
   cloud_task_app_test:

--- a/gradle/plugins/aot-smoke-test-ci-plugin/src/main/java/org/springframework/aot/gradle/GenerateGitHubActionsWorkflows.java
+++ b/gradle/plugins/aot-smoke-test-ci-plugin/src/main/java/org/springframework/aot/gradle/GenerateGitHubActionsWorkflows.java
@@ -69,19 +69,17 @@ public abstract class GenerateGitHubActionsWorkflows extends DefaultTask {
 	void generateWorkflow(SmokeTest smokeTest) {
 		String springBootGeneration = getSpringBootGeneration().get();
 		File workflowFile = getOutputDirectory()
-			.file(springBootGeneration + "-" + smokeTest.group() + "-" + smokeTest.name() + ".yml")
+			.file(getSpringBootGeneration().get() + "-" + smokeTest.group() + "-" + smokeTest.name() + ".yml")
 			.get()
 			.getAsFile();
 		workflowFile.getParentFile().mkdirs();
-		String workflowName = springBootGeneration + " | " + name(smokeTest.group()) + " Smoke Tests | "
+		String workflowName = getSpringBootGeneration().get() + " | " + name(smokeTest.group()) + " Smoke Tests | "
 				+ name(smokeTest.name());
 		try (PrintWriter writer = new PrintWriter(new FileWriter(workflowFile))) {
 			writer.println("name: " + workflowName);
 			writer.println("on:");
-			if (!"cloud".equals(smokeTest.group()) || !springBootGeneration.equals("3.4.x")) {
-				writer.println("  schedule:");
-				writer.println("    - cron : '" + getCronSchedule().get() + "'");
-			}
+			writer.println("  schedule:");
+			writer.println("    - cron : '" + getCronSchedule().get() + "'");
 			writer.println("  workflow_dispatch:");
 			writer.println("jobs:");
 			smokeTest.tests().forEach((test) -> {


### PR DESCRIPTION
This reverts commit 2c2651a1697af9e77d71f476bc05505ff111a9a2.

Spring Cloud 2024.0.x snapshots with Boot 3.4 support are now available.