### PR TITLE
Adjust `integration` app to the latest Spring Integration

### DIFF
--- a/integration/integration/src/appTest/java/com/example/integration/IntegrationApplicationTests.java
+++ b/integration/integration/src/appTest/java/com/example/integration/IntegrationApplicationTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,9 +33,9 @@ public class IntegrationApplicationTests {
 
 	@Test
 	void shouldOutputIntegrationGraph(WebTestClient client, AssertableOutput output) {
-		client.get().uri("/control-bus/dateSourceEndpoint").exchange().expectStatus().isOk();
+		client.post().uri("/control-bus/dateSourceEndpoint.start").exchange().expectStatus().isOk();
 
-		output.assertThat().hasSingleLineContaining("Starting endpoint: dateSourceEndpoint");
+		output.assertThat().hasSingleLineContaining("started bean 'dateSourceEndpoint'");
 
 		Awaitility.await()
 			.atMost(Duration.ofSeconds(30))


### PR DESCRIPTION
Spring Integration now provides a new API for Control Bus: https://github.com/spring-projects/spring-integration/issues/9381.
That includes a `ControlBusController` for REST management.