### PR TITLE
Add test for Spring Data fragments API

### DIFF
--- a/data/data-jpa/src/appTest/java/com/example/data/jpa/DataJpaApplicationAotTests.java
+++ b/data/data-jpa/src/appTest/java/com/example/data/jpa/DataJpaApplicationAotTests.java
@@ -116,4 +116,11 @@ class DataJpaApplicationAotTests {
 		});
 	}
 
+	@Test
+	void fragmentsApi(AssertableOutput output) {
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			assertThat(output).hasSingleLineContaining("fragmentsApi(): RepositoryExtension says hello to Book");
+		});
+	}
+
 }

--- a/data/data-jpa/src/main/java/com/acme/data/jpa/extension/DefaultRepositoryExtension.java
+++ b/data/data-jpa/src/main/java/com/acme/data/jpa/extension/DefaultRepositoryExtension.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.acme.data.jpa.extension;
+
+import org.springframework.data.repository.core.RepositoryMethodContext;
+import org.springframework.data.repository.core.support.RepositoryMetadataAccess;
+
+class DefaultRepositoryExtension<T> implements RepositoryExtension<T>, RepositoryMetadataAccess {
+
+	@Override
+	public String extensionMethod(String arg) {
+
+		return "RepositoryExtension says %s to %s".formatted(arg,
+				RepositoryMethodContext.getContext().getMetadata().getDomainType().getSimpleName());
+	}
+
+}

--- a/data/data-jpa/src/main/java/com/acme/data/jpa/extension/RepositoryExtension.java
+++ b/data/data-jpa/src/main/java/com/acme/data/jpa/extension/RepositoryExtension.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.acme.data.jpa.extension;
+
+public interface RepositoryExtension<T> {
+
+	String extensionMethod(String arg);
+
+}

--- a/data/data-jpa/src/main/java/com/example/data/jpa/BookRepository.java
+++ b/data/data-jpa/src/main/java/com/example/data/jpa/BookRepository.java
@@ -15,12 +15,13 @@
  */
 package com.example.data.jpa;
 
+import com.acme.data.jpa.extension.RepositoryExtension;
 import com.example.data.jpa.model.Book;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 
-public interface BookRepository extends ListCrudRepository<Book, Long> {
+public interface BookRepository extends ListCrudRepository<Book, Long>, RepositoryExtension<Book> {
 
 	@EntityGraph(attributePaths = "authors")
 	@Query("SELECT b FROM Book b WHERE b.title = :title")

--- a/data/data-jpa/src/main/java/com/example/data/jpa/TransactionalRunner.java
+++ b/data/data-jpa/src/main/java/com/example/data/jpa/TransactionalRunner.java
@@ -42,6 +42,7 @@ class TransactionalRunner implements CommandLineRunner {
 		deleteAll();
 		entityGraph();
 		insertPublishers(); // uses AbstractPersistable
+		fragmentsApi();
 	}
 
 	private void deleteAll() {
@@ -117,6 +118,10 @@ class TransactionalRunner implements CommandLineRunner {
 		Publisher publisher1 = this.publisherRepository.save(new Publisher("independently published"));
 		System.out.printf("insertPublishers(): publisher1 - %s%n", publisher1);
 		return List.of(publisher1);
+	}
+
+	private void fragmentsApi() {
+		System.out.printf("fragmentsApi(): %s%n", this.bookRepository.extensionMethod("hello"));
 	}
 
 }

--- a/data/data-jpa/src/main/resources/META-INF/spring.factories
+++ b/data/data-jpa/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+com.acme.data.jpa.extension.RepositoryExtension=com.acme.data.jpa.extension.DefaultRepositoryExtension


### PR DESCRIPTION
Extend the data-jpa test to cover the repository extension mechanism (new in the 2024.1 release) using `spring.factories` to detect fragments outside the base package.
Make sure the newly introduced `RepositoryMetadataAccess` marker interface works and provides invocation metadata via `RepositoryMethodContext`. 