### PR TITLE
Upgrade Cloud to 2025.0.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ kotlinVersion=1.9.24
 javaFormatVersion=0.0.39
 nbtVersion=0.10.3
 springBootVersion=3.5.1-SNAPSHOT
-springCloudVersion=2025.0.0-SNAPSHOT
+springCloudVersion=2025.0.1-SNAPSHOT
 springBootGeneration=3.5.x


### PR DESCRIPTION
This should also fix failing GW MVC tests.