### PR TITLE
Add smoke tests for Spring Cloud Gateway MVC.

### DIFF
--- a/cloud/cloud-gateway-mvc/build.gradle
+++ b/cloud/cloud-gateway-mvc/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+	id "java"
+	id "org.springframework.boot"
+	id "org.springframework.aot.smoke-test"
+	id "org.graalvm.buildtools.native"
+}
+
+dependencies {
+	implementation(enforcedPlatform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+	implementation(enforcedPlatform("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"))
+	implementation("org.springframework.cloud:spring-cloud-starter-gateway-mvc")
+	implementation("org.springframework.cloud:spring-cloud-starter-loadbalancer")
+	implementation("org.springframework.retry:spring-retry")
+
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+	appTestImplementation(project(":aot-smoke-test-support"))
+}
+
+aotSmokeTest {
+	webApplication = true
+}

--- a/cloud/cloud-gateway-mvc/docker-compose.yml
+++ b/cloud/cloud-gateway-mvc/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  test-service:
+    image: springcloud/test-service:latest
+    ports:
+      - "8081"
+  demo-service:
+    image: springcloud/demo-service:latest
+    ports:
+      - "8082"

--- a/cloud/cloud-gateway-mvc/src/appTest/java/com/example/cloud/gateway/CloudGatewayApplicationAotTests.java
+++ b/cloud/cloud-gateway-mvc/src/appTest/java/com/example/cloud/gateway/CloudGatewayApplicationAotTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.cloud.gateway;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.smoketest.support.junit.ApplicationTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ApplicationTest
+public class CloudGatewayApplicationAotTests {
+
+	@Test
+	void shouldRouteRequests(WebTestClient client) {
+		client.get()
+			.uri("test-service")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.consumeWith((result) -> assertThat(new String(result.getResponseBodyContent())).isEqualTo("test"));
+		client.get()
+			.uri("demo-service")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.consumeWith((result) -> assertThat(new String(result.getResponseBodyContent())).isEqualTo("demo"));
+	}
+
+}

--- a/cloud/cloud-gateway-mvc/src/main/java/org/example/cloud/gateway/CloudGatewayApplication.java
+++ b/cloud/cloud-gateway-mvc/src/main/java/org/example/cloud/gateway/CloudGatewayApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * limitations under the License.
+ */
+
+package org.example.cloud.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CloudGatewayApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(CloudGatewayApplication.class, args);
+	}
+
+}

--- a/cloud/cloud-gateway-mvc/src/main/java/org/example/cloud/gateway/config/RoutesConfig.java
+++ b/cloud/cloud-gateway-mvc/src/main/java/org/example/cloud/gateway/config/RoutesConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.example.cloud.gateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.springframework.cloud.gateway.server.mvc.filter.BeforeFilterFunctions.stripPrefix;
+import static org.springframework.cloud.gateway.server.mvc.filter.LoadBalancerFilterFunctions.lb;
+import static org.springframework.cloud.gateway.server.mvc.handler.GatewayRouterFunctions.route;
+import static org.springframework.cloud.gateway.server.mvc.handler.HandlerFunctions.http;
+
+@Configuration
+class RoutesConfig {
+
+	@Bean
+	RouterFunction<ServerResponse> demoServiceRoute() {
+		return route("demo_service_route").GET("/demo-service/**", http())
+			.before(stripPrefix(1))
+			.filter(lb("demo-service"))
+			.build();
+	}
+
+}

--- a/cloud/cloud-gateway-mvc/src/main/resources/application.yml
+++ b/cloud/cloud-gateway-mvc/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+spring:
+  application:
+    name: gateway
+  cloud:
+    refresh:
+      enabled: false
+    discovery:
+      client:
+        simple:
+            instances:
+              test-service:
+                - uri: http://${TEST-SERVICE_HOST:localhost}:${TEST-SERVICE_PORT_8081:8081}
+              demo-service:
+                - uri: http://${DEMO-SERVICE_HOST:localhost}:${DEMO-SERVICE_PORT_8082:8082}
+    loadbalancer:
+      eager-load:
+        clients:
+          - demo-service
+          - test-service
+    gateway:
+      mvc:
+        routes:
+          - id: test_service_route
+            uri: lb://test-service
+            predicates:
+              - Path=/test-service/**
+            filters:
+              - StripPrefix=1
+              - name: Retry
+                args:
+                  retries: 3

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ kotlinVersion=1.9.24
 javaFormatVersion=0.0.39
 nbtVersion=0.10.3
 springBootVersion=3.3.13-SNAPSHOT
-springCloudVersion=2023.0.4-SNAPSHOT
+springCloudVersion=2023.0.6-SNAPSHOT
 springBootGeneration=3.3.x


### PR DESCRIPTION
This (apart from the SC version) should then be merged forward to  `3.4.x`, but not `main` - a different version is already there.