### PR TITLE
Upgrade Spring Cloud version to 2024.0.4-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ kotlinVersion=1.9.24
 javaFormatVersion=0.0.47
 nbtVersion=0.10.6
 springBootVersion=3.4.13-SNAPSHOT
-springCloudVersion=2024.0.1-SNAPSHOT
+springCloudVersion=2024.0.4-SNAPSHOT
 springBootGeneration=3.4.x


### PR DESCRIPTION
Update the Spring Cloud dependency from 2024.0.1-SNAPSHOT to 2024.0.4-SNAPSHOT in gradle.properties.