### PR TITLE
Add test for data-redis declarative message listeners.

### DIFF
--- a/data/data-redis/src/appTest/java/com/example/data/redis/DataRedisApplicationAotTests.java
+++ b/data/data-redis/src/appTest/java/com/example/data/redis/DataRedisApplicationAotTests.java
@@ -84,6 +84,14 @@ class DataRedisApplicationAotTests {
 	}
 
 	@Test
+	void messageListeners(AssertableOutput output) {
+		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+			assertThat(output)
+				.hasSingleLineContaining("message-listener: received [payload] from [string-channel] at ");
+		});
+	}
+
+	@Test
 	void findAll(AssertableOutput output) {
 		Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
 			assertThat(output).hasSingleLineContaining("findAll(): Person{firstname='first-1', lastname='last-1'}")

--- a/data/data-redis/src/main/java/com/example/data/redis/CLR.java
+++ b/data/data-redis/src/main/java/com/example/data/redis/CLR.java
@@ -28,9 +28,12 @@ import org.springframework.data.redis.hash.JacksonHashMapper;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.messaging.RedisMessageSendingOperations;
+import org.springframework.data.redis.messaging.RedisMessageSendingTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.support.collections.DefaultRedisSet;
 import org.springframework.data.redis.support.collections.RedisSet;
+import org.springframework.messaging.core.MessageSendingOperations;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -59,6 +62,7 @@ class CLR implements CommandLineRunner {
 		hashMapper(HashStructure.FLAT);
 		jsonSerializer();
 		pubSub();
+		messageListener();
 
 		this.personRepository.save(new Person("first-1", "last-1"));
 		this.personRepository.save(new Person("first-2", "last-2"));
@@ -141,6 +145,16 @@ class CLR implements CommandLineRunner {
 
 		Thread.sleep(100);
 		System.out.printf("pub/sub: %s%n", this.messageHandler.receivedMessages());
+
+		container.stop();
+	}
+
+	private void messageListener() {
+
+		String channel = Messaging.STRING_CHANNEL;
+
+		RedisMessageSendingOperations sender = new RedisMessageSendingTemplate(template);
+		sender.convertAndSend(channel, "payload");
 	}
 
 	enum HashStructure {

--- a/data/data-redis/src/main/java/com/example/data/redis/Messaging.java
+++ b/data/data-redis/src/main/java/com/example/data/redis/Messaging.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.data.redis;
+
+import org.springframework.data.redis.annotation.RedisListener;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Messaging {
+
+	public static final String STRING_CHANNEL = "string-channel";
+
+	/**
+	 * Declarative channel listener capturing raw {@link String}s received from Redis via
+	 * the {@literal string-channel}.
+	 * @param data the payload received via the {@literal string-channel}.
+	 * @param headers {@link MessageHeaders} when receiving the message.
+	 */
+	@RedisListener(topic = STRING_CHANNEL)
+	public void processStringMessage(@Payload String data, MessageHeaders headers) {
+
+		System.out.printf("message-listener: received [%s] from [%s] at [%s].%n", data, headers.get("channel"),
+				headers.getTimestamp());
+	}
+
+}


### PR DESCRIPTION
Add a test that covers setup and  boot auto configuration for [Annotation-driven Pub/Sub Listener Endpoints](https://github.com/spring-projects/spring-data-commons/wiki/Spring-Data-2026.0-Release-Notes#annotation-driven-pubsub-listener-endpoints) by publishing a simple String message to a dedicated Redis channel and asserting it is received by the endpoint listening.

See: spring-projects/spring-data-redis#1004