### PR TITLE
spring-retry dependency is missing for cloud-task

### DIFF
--- a/cloud/cloud-task/build.gradle
+++ b/cloud/cloud-task/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation(enforcedPlatform("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"))
 	implementation("org.springframework.boot:spring-boot-starter")
 	implementation("org.springframework.cloud:spring-cloud-starter-task")
+	implementation("org.springframework.retry:spring-retry")
 	runtimeOnly("com.h2database:h2")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")


### PR DESCRIPTION
- This branch is currently failing because it can't resolve spring-retry since it was removed from boot.